### PR TITLE
Tasks and workers time information

### DIFF
--- a/clearly/__init__.py
+++ b/clearly/__init__.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 
 __author__ = 'Rogério Sampaio de Almeida'
 
-VERSION = (0, 2, 1)  # 'major', 'minor', 'release'
+VERSION = (0, 2, 2)  # 'major', 'minor', 'release'
 __version__ = '.'.join(map(str, VERSION))
 
 from .client import ClearlyClient

--- a/clearly/client.py
+++ b/clearly/client.py
@@ -235,8 +235,14 @@ class ClearlyClient(object):
                   worker.loadavg or DIM_NONE,
                   colors.DIM('processed:'), worker.processed or DIM_NONE)
             if worker.alive:
+                if worker.heartbeat:
+                    ts = datetime.fromtimestamp(worker.heartbeat)
+                    tsstr = ts.strftime('%H:%M:%S.%f')[:-3]
+                else:
+                    tsstr = DIM_NONE
                 print(colors.DIM('{:>{}}'.format('heartbeat:', HEADER_SIZE)),
-                      '/{}s'.format(worker.freq))
+                      '/{}s'.format(worker.freq),
+                      colors.DIM(tsstr))
 
     @staticmethod
     def _task_state(state):

--- a/clearly/client.py
+++ b/clearly/client.py
@@ -222,7 +222,7 @@ class ClearlyClient(object):
             print(colors.DIM('{:>{}}'.format('==>', HEADER_SIZE)), output)
 
     def _display_worker(self, worker, show_params):
-        print(self._worker_state(worker),
+        print(self._worker_state(worker.alive),
               colors.DIM(colors.CYAN(worker.hostname)),
               colors.DIM(colors.YELLOW(str(worker.pid))))
 

--- a/clearly/client.py
+++ b/clearly/client.py
@@ -126,7 +126,7 @@ class ClearlyClient(object):
               '\ttasks', colors.RED(tasks),
               '\tworkers', colors.RED(workers))
 
-    def tasks(self, pattern=None, state=None,
+    def tasks(self, pattern=None, state=None, negate=False,
               params=None, success=False, error=False):
         """Filters captured tasks and prints their current status.
         There are a few params with different defaults from the equivalent
@@ -139,6 +139,7 @@ class ClearlyClient(object):
                       or 'dispatch.*123456' to filter that exact name and number
                       or even '123456' to filter that exact number anywhere.
             state (Optional[str]): a state to filter tasks
+            negate (bool): if True, finds tasks that do not match criteria
             params (Optional[bool]): if True shows params of all tasks,
                 if False doesn't, if None use the success or error,
                 depending on the final state
@@ -149,13 +150,14 @@ class ClearlyClient(object):
                 default is False, to get an overview.
 
         """
-        for task in self._clearly_server.tasks(pattern, state):  # type:TaskInfo
+        for task in self._clearly_server.tasks(pattern, state,
+                                               negate):  # type:TaskInfo
             show = _is_to_result(task.state, success, error)
             self._display_task(task,
                                params if params is not None else show,
                                show)
 
-    def workers(self, pattern=None, stats=True):
+    def workers(self, pattern=None, negate=False, stats=True):
         """Filters known workers and prints their current status.
         
         Args:
@@ -163,10 +165,12 @@ class ClearlyClient(object):
                 ex.: '^dispatch|^email' to filter names starting with those
                       or 'dispatch.*123456' to filter that exact name and number
                       or even '123456' to filter that exact number anywhere.
+            negate (bool): if True, finds tasks that do not match criteria
             stats (bool): if True shows worker stats
 
         """
-        for worker in self._clearly_server.workers(pattern):  # type:WorkerInfo
+        for worker in self._clearly_server.workers(pattern,
+                                                   negate):  # type:WorkerInfo
             self._display_worker(worker, stats)
 
     def task(self, task_uuid):

--- a/clearly/client.py
+++ b/clearly/client.py
@@ -192,6 +192,8 @@ class ClearlyClient(object):
         self._clearly_server.reset()
 
     def _display_task(self, task, show_params, show_result):
+        ts = datetime.fromtimestamp(task.timestamp)
+        print(colors.DIM(ts.strftime('%H:%M:%S.%f')[:-3]), end=' ')
         if task.created:
             print(colors.BLUE(task.name),
                   colors.MAGENTA(task.routing_key[len(task.name):] or '-'

--- a/clearly/client.py
+++ b/clearly/client.py
@@ -201,7 +201,7 @@ class ClearlyClient(object):
                   colors.DIM(task.uuid))
         else:
             print(self._task_state(task.state),
-                  colors.DIM(colors.YELLOW(task.retries)),
+                  colors.DIM(colors.BLUE(task.retries)),
                   end=' ')
             print(colors.BLUE(task.name), colors.DIM(task.uuid))
 

--- a/clearly/serializer.py
+++ b/clearly/serializer.py
@@ -1,10 +1,9 @@
 # coding=utf-8
+from collections import namedtuple
 from itertools import chain
 
-from collections import namedtuple
-
 TASK_OWN_FIELDS = ('name', 'routing_key', 'uuid', 'retries', 'args', 'kwargs',
-                   'result', 'traceback')
+                   'result', 'traceback', 'timestamp')
 TASK_DYNAMIC_FIELDS = ('state', 'created')
 TASK_FIELDS = TASK_OWN_FIELDS + TASK_DYNAMIC_FIELDS
 

--- a/clearly/serializer.py
+++ b/clearly/serializer.py
@@ -20,7 +20,7 @@ WorkerInfo = namedtuple('WorkerInfo', WORKER_FIELDS)
 def serialize_task(task, state, created):
     return TaskInfo._make(chain(
         (getattr(task, f) for f in TASK_OWN_FIELDS),
-        (v for v in (state, created))
+        (state, created)
     ))
 
 

--- a/clearly/serializer.py
+++ b/clearly/serializer.py
@@ -9,8 +9,11 @@ TASK_FIELDS = TASK_OWN_FIELDS + TASK_DYNAMIC_FIELDS
 
 TaskInfo = namedtuple('TaskInfo', TASK_FIELDS)
 
-WORKER_FIELDS = ('hostname', 'pid', 'sw_sys', 'sw_ident', 'sw_ver', 'loadavg',
-                 'processed', 'alive', 'freq')
+WORKER_OWN_FIELDS = ('hostname', 'pid', 'sw_sys', 'sw_ident', 'sw_ver',
+                     'loadavg', 'processed', 'alive', 'freq')
+WORKER_DYNAMIC_FIELDS = ('heartbeat',)
+WORKER_FIELDS = WORKER_OWN_FIELDS + WORKER_DYNAMIC_FIELDS
+
 WorkerInfo = namedtuple('WorkerInfo', WORKER_FIELDS)
 
 
@@ -22,4 +25,7 @@ def serialize_task(task, state, created):
 
 
 def serialize_worker(worker):
-    return WorkerInfo._make(getattr(worker, f) for f in WORKER_FIELDS)
+    return WorkerInfo._make(chain(
+        (getattr(worker, f) for f in WORKER_OWN_FIELDS),
+        (worker.heartbeats[-1] if worker.heartbeats else None,)
+    ))

--- a/clearly/server.py
+++ b/clearly/server.py
@@ -189,7 +189,8 @@ class ClearlyServer(object):
         if pattern:
             regex = re.compile(pattern)
             pcondition = lambda task: \
-                regex.search(task.name) or regex.search(task.routing_key)
+                regex.search(task.name or '') or \
+                regex.search(task.routing_key or '')
         if state:
             scondition = lambda task: task.state == state
 


### PR DESCRIPTION
Several small improvements, like:
- timestamp of tasks;
- heartbeat of workers;
- smaller params names, like `show_params` to `params`;
- negate flag in tasks and workers, to negate the result of a search by pattern.