### PR TITLE
fix(server) CLI kwargs compatibility with Python 2

### DIFF
--- a/clearly/command_line.py
+++ b/clearly/command_line.py
@@ -28,5 +28,5 @@ def server(**kwargs):
 
         BROKER: The broker being used by celery, like "amqp://localhost".
     """
-    start_server(**{k: v for k, v in kwargs.items() if v},
-                 blocking=True)
+    start_server(blocking=True,
+                 **{k: v for k, v in kwargs.items() if v})


### PR DESCRIPTION
Python2 doesn't support other keyword arguments after **kwargs