### PR TITLE
Fix tests in python 3.7

### DIFF
--- a/clearly/__init__.py
+++ b/clearly/__init__.py
@@ -1,7 +1,7 @@
 # coding=utf-8
 from __future__ import absolute_import, print_function, unicode_literals
 
-VERSION = (0, 6, 3)
+VERSION = (0, 6, 4)
 
 __author__ = 'Rogério Sampaio de Almeida'
 __email__ = 'rsalmei@gmail.com'

--- a/clearly/expected_state.py
+++ b/clearly/expected_state.py
@@ -25,7 +25,7 @@ class ExpectedStateHandler(object):
 
     def states_through(self, pre, post):
         if pre == post:
-            raise StopIteration
+            return
 
         pointer = self.expected_path
         expected = pre

--- a/tests/unit/test_safe_compiler.py
+++ b/tests/unit/test_safe_compiler.py
@@ -22,8 +22,8 @@ from clearly.safe_compiler import CallDescriptor, safe_compile_text
     ('"a\\na"', 'a\na'),
     ('"a\\\na"', 'a\\x0aa'),
     ('"a\\\\na"', 'a\\na'),
-    ('"\j"', '\j'),
-    ('"\\j"', '\j'),
+    ('"\r"', '\r'),
+    ('"\\r"', '\r'),
     ('"\a\n\r\t"', '\a\n\r\t'),
 
     # simple tuples


### PR DESCRIPTION
In python 3.7, [PEP-479](https://www.python.org/dev/peps/pep-0479/) turned into a error raising `StopIteration` inside a generator function.