### PR TITLE
Fix about_time unpinned

### DIFF
--- a/clearly/__init__.py
+++ b/clearly/__init__.py
@@ -1,4 +1,4 @@
-VERSION = (0, 7, 0)
+VERSION = (0, 7, 1)
 
 __author__ = 'Rogério Sampaio de Almeida'
 __email__ = 'rsalmei@gmail.com'

--- a/clearly/client.py
+++ b/clearly/client.py
@@ -109,10 +109,10 @@ class ClearlyClient(object):
               '\tworkers', Colors.RED(stats.len_workers))
 
     @staticmethod
-    def _fetched_callback(t):  # pragma: no cover
+    def _fetched_callback(at):  # pragma: no cover
         print('{} {} in {} ({})'.format(
-            Colors.DIM('fetched:'), Colors.BOLD(t.count),
-            Colors.GREEN(t.duration_human), Colors.GREEN(t.throughput_human)
+            Colors.DIM('fetched:'), Colors.BOLD(at.count),
+            Colors.GREEN(at.duration_human), Colors.GREEN(at.throughput_human)
         ))
 
     def tasks(self, pattern=None, negate=False, state=None, limit=None, reverse=True,
@@ -154,8 +154,10 @@ class ClearlyClient(object):
             state_pattern=state or '.', limit=limit, reverse=reverse
         )
 
-        for task in about_time(ClearlyClient._fetched_callback, self._stub.filter_tasks(request)):
+        at = about_time(self._stub.filter_tasks(request))
+        for task in at:
             ClearlyClient._display_task(task, params, success, error)
+        ClearlyClient._fetched_callback(at)
 
     def workers(self, pattern=None, negate=False, stats=True):
         """Filters known workers and prints their current status.
@@ -178,8 +180,10 @@ class ClearlyClient(object):
                                                      negate=negate),
         )
 
-        for worker in about_time(ClearlyClient._fetched_callback, self._stub.filter_workers(request)):
+        at = about_time(self._stub.filter_workers(request))
+        for worker in at:
             ClearlyClient._display_worker(worker, stats)
+        ClearlyClient._fetched_callback(at)
 
     def task(self, task_uuid):
         """Finds one specific task.

--- a/clearly/client.py
+++ b/clearly/client.py
@@ -17,7 +17,6 @@ DIM_NONE = Colors.DIM(Colors.CYAN('None'))
 TRACEBACK_HIGHLIGHTER = create_traceback_highlighter()
 
 
-
 class ClearlyClient(object):
     """Simple and real-time monitor for celery.
     Client object, to display and manage server captured tasks and workers.
@@ -224,12 +223,12 @@ class ClearlyClient(object):
             print(Colors.BLUE(task.name), Colors.DIM(task.uuid))
 
         show_result = (task.state in states.EXCEPTION_STATES and error) \
-                      or (task.state == states.SUCCESS and success)
+            or (task.state == states.SUCCESS and success)
 
         first_seen = bool(params) and task.created
         result = params is not False \
-                 and (task.state in states.READY_STATES) \
-                 and show_result
+            and (task.state in states.READY_STATES) \
+            and show_result
         if first_seen or result:
             print(Colors.DIM('{:>{}}'.format('args:', HEADER_SIZE)),
                   typed_code(safe_compile_text(task.args),

--- a/clearly/server.py
+++ b/clearly/server.py
@@ -90,8 +90,10 @@ class ClearlyServer(clearly_pb2_grpc.ClearlyServerServicer):
         keys = klass.DESCRIPTOR.fields_by_name.keys()
         # noinspection PyProtectedMember
         data = {k: v for k, v in
-                getattr(event, '_asdict',  # internal TaskData and WorkerData
-                        lambda: {f: getattr(event, f) for f in event._fields})  # celery Task and Worker
+                getattr(
+                    event, '_asdict',  # internal TaskData and WorkerData
+                    lambda: {f: getattr(event, f) for f in event._fields}  # celery Task and Worker
+                )
                 ().items() if k in keys}
         return key, klass(**data)
 
@@ -183,7 +185,8 @@ def _log_request(request, context):  # pragma: no cover
 
 
 def _setup_logging(debug):  # pragma: no cover
-    f = Colors.DIM('%(asctime)s') + Colors.MAGENTA(' %(name)s') + Colors.BLUE(' %(levelname)s') + ' %(message)s'
+    f = Colors.DIM('%(asctime)s') + Colors.MAGENTA(' %(name)s')\
+        + Colors.BLUE(' %(levelname)s') + ' %(message)s'
     logging.basicConfig(level=logging.WARNING, format=f)
     logging.getLogger('clearly').setLevel(logging.DEBUG if debug else logging.INFO)
 

--- a/clearly/server.py
+++ b/clearly/server.py
@@ -116,12 +116,11 @@ class ClearlyServer(clearly_pb2_grpc.ClearlyServerServicer):
                                                           reverse=reverse)
                        if pcondition(task) and scondition(task))
 
-        def callback(t):
-            logger.debug('%s iterated %d tasks in %s (%s)', self.filter_tasks.__name__,
-                         t.count, t.duration_human, t.throughput_human)
-
-        for task in about_time(callback, found_tasks):
+        at = about_time(found_tasks)
+        for task in at:
             yield ClearlyServer._event_to_pb(task)[1]
+        logger.debug('%s iterated %d tasks in %s (%s)', self.filter_tasks.__name__,
+                     at.count, at.duration_human, at.throughput_human)
 
     def filter_workers(self, request, context):
         """Filter workers by matching a pattern to hostname."""
@@ -138,12 +137,11 @@ class ClearlyServer(clearly_pb2_grpc.ClearlyServerServicer):
                                 key=WORKER_HOSTNAME_OP)
                          if hcondition(worker))
 
-        def callback(t):
-            logger.debug('%s iterated %d workers in %s (%s)', self.filter_workers.__name__,
-                         t.count, t.duration_human, t.throughput_human)
-
-        for worker in about_time(callback, found_workers):
+        at = about_time(found_workers)
+        for worker in at:
             yield ClearlyServer._event_to_pb(worker)[1]
+        logger.debug('%s iterated %d workers in %s (%s)', self.filter_workers.__name__,
+                     at.count, at.duration_human, at.throughput_human)
 
     def find_task(self, request, context):
         """Finds one specific task."""

--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-.PHONY: clean build protos
+.PHONY: all install clean build release protos test ptw
 
 # grpc related
 SRC = clearly

--- a/requirements/install.txt
+++ b/requirements/install.txt
@@ -3,4 +3,4 @@ pygments
 grpcio
 protobuf
 click
-about-time
+about-time~=3.0

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ def get_readme():
 setup(
     name='clearly',
     version=clearly.__version__,
-    description='Simple and accurate real-time monitor for celery',
+    description='Clearly see and debug your celery pool in real time!',
     long_description=get_readme(),
     long_description_content_type='text/markdown',
     url='https://github.com/rsalmei/clearly',


### PR DESCRIPTION
I did yesterday a major refac in about_time, making it much simpler to use!
And it wasn't pinned in here, so the next push I've made, got the new version and broke.
I like to always pin up to the minor version, so the project always gets build fixes, so I've pinned to `~=3.0` 😉 

If you don't know `about_time`, please do! It ended up pretty nice, and more people should know it: https://github.com/rsalmei/about-time